### PR TITLE
Fixed missing module backports on python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ youtube_dl
 pytz
 six
 pycryptodome
+backports-zoneinfo
+tzdata


### PR DESCRIPTION
Added backports-zoneinfo to requirements. CUTVM's PR workflow runs on python 3.8, which needs the backport.

@joaopa00 , just a ping to be sure. You probably aren't expecting yet another PR in the repo ;-)